### PR TITLE
SRE-117-adding-db-probe

### DIFF
--- a/live/common/postgres/terragrunt.hcl
+++ b/live/common/postgres/terragrunt.hcl
@@ -33,9 +33,11 @@ locals {
 }
 
 inputs = {
-  databases = try(local.deploy_yaml.infrastructure.postgres, [])
-  app_name  = local.deploy_yaml.name
-  namespace = dependency.namespace.outputs.namespace_name
+  databases    = try(local.deploy_yaml.infrastructure.postgres, [])
+  app_name     = local.deploy_yaml.name
+  app_type     = try(local.deploy_yaml.api, false) != false || try(local.deploy.handler, false) != false
+  namespace    = dependency.namespace.outputs.namespace_name
+  service_port = try(local.deploy_yaml.api.service.port, try(local.deploy_yaml.handler.service.port, 80))
   labels = merge(
     {
       "app" : local.deploy_yaml.name,

--- a/modules/common/postgres/README.md
+++ b/modules/common/postgres/README.md
@@ -4,13 +4,15 @@
 
 ### postgres
 
-| Key        | Type         | Default | Description                          | Example       | Required |
-| ---------- | ------------ | ------- | ------------------------------------ | ------------- | -------- |
-| name       | string       |         | Name of the database to be created   | test-database | yes      |
-| reference  | string       |         | Short name to reference the database | test          | yes      |
-| role_name  | string       |         | Name of the role                     | admin         | yes      |
-| read_only  | bool         |         | Create database with read-only-user  | true          | optional |
-| extensions | list(string) | [ ]     | Array of extensions                  | ["postgis"]   | optional |
+| Key          | Type         | Default | Description                          | Example       | Required |
+| ------------ | ------------ | ------- | ------------------------------------ | ------------- | -------- |
+| name         | string       |         | Name of the database to be created   | test-database | yes      |
+| reference    | string       |         | Short name to reference the database | test          | yes      |
+| role_name    | string       |         | Name of the role                     | admin         | yes      |
+| read_only    | bool         |         | Create database with read-only-user  | true          | optional |
+| extensions   | list(string) | [ ]     | Array of extensions                  | ["postgis"]   | optional |
+| create_probe | bool         |         | Create database probe                | true          | optional |
+| db_endpoint  | string       |         | Endpoint of database health check    | health/db     | optional |
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -33,6 +35,7 @@
 | Name | Type |
 |------|------|
 | [kubernetes_config_map.postgres](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_manifest.probe](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [aws_secretsmanager_secret_version.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
@@ -40,9 +43,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Release name of the app | `string` | n/a | yes |
+| <a name="input_app_type"></a> [app\_type](#input\_app\_type) | Returns true if the application is a handler or api | `bool` | n/a | yes |
 | <a name="input_databases"></a> [databases](#input\_databases) | List of Postgres Databases to create. [ name, reference, role\_name, read\_only (Optional: false), extensions (Optional: []) ] | `any` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Map of Labels to be applied to config maps | `map(string)` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name of the app | `string` | n/a | yes |
+| <a name="input_service_port"></a> [service\_port](#input\_service\_port) | Exposed Port of application | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/common/postgres/main.tf
+++ b/modules/common/postgres/main.tf
@@ -38,3 +38,31 @@ resource "kubernetes_config_map" "postgres" {
     "DATABASE__${each.value.reference}__password" = module.database[each.key].password
   }
 }
+
+resource "kubernetes_manifest" "probe" {
+  for_each = { for k, v in local.database_map : k => v if(
+  var.app_type ? lookup(v, "create_probe", true) : false) }
+  manifest = {
+    "kind" : "Probe",
+    "apiVersion" : "monitoring.coreos.com/v1",
+    "metadata" : {
+      "name" : "${each.value.name}"
+      "namespace" : "${var.namespace}"
+      "labels" : "${var.labels}"
+    },
+    "spec" : {
+      "interval" : "10s",
+      "module" : "http_2xx",
+      "prober" : {
+        "url" : "prometheus-blackbox-prometheus-blackbox-exporter.prometheus:9115"
+      },
+      "targets" : {
+        "staticConfig" : {
+          "static" : [
+            "${var.app_name}.${var.namespace}.svc:${var.service_port}/${lookup(each.value, "db_endpoint", "health/db")}"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/modules/common/postgres/variables.tf
+++ b/modules/common/postgres/variables.tf
@@ -17,3 +17,13 @@ variable "labels" {
   description = "Map of Labels to be applied to config maps"
   type        = map(string)
 }
+
+variable "service_port" {
+  type        = string
+  description = "Exposed Port of application"
+}
+
+variable "app_type" {
+  type        = bool
+  description = "Returns true if the application is a handler or api"
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

These are some changes to the terragrunt postgres module. Creates a probe crd to probe a database health check endpoint.

Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Deployed [dummy-application](https://github.com/variant-inc/dummy-application-dx/tree/SRE-117/testing-terragrunt) that used the postgres module and used different inputs to test the new functionality. First without any input changes. Second with the create_probe value set to false, and finally with the db_endpoint set to an empty string.

[Octopus Release](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/dummy-application-dx/deployments/releases/0.1.0-sre-117-testing-0001.15/deployments/Deployments-40877?activeTab=taskLog)
![image](https://user-images.githubusercontent.com/63361757/176741001-9179bdf9-92bf-4cef-a2ae-9b668560752b.png)

[create_probe: false](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/dummy-application-dx/deployments/releases/0.1.0-sre-117-testing-0001.16/deployments/Deployments-40879?activeTab=taskLog)

[db_endpoint: ""](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/dummy-application-dx/deployments/releases/0.1.0-sre-117-testing-0001.18/deployments/Deployments-40982?activeTab=taskLog)
![image](https://user-images.githubusercontent.com/63361757/176748902-3331c566-bf04-4b2c-9993-578614a5d8cb.png)


Provide instructions so we can reproduce.
Can test by deploying a demo application that uses the postgres module and setting the deploy_package_version to 1.0.1-896bcda0001.451 in Actions-Octopus. Check the probe resources and confirm that a probe object was created and that the pod logs show traces for the /health/db endpoint.
Please also list any relevant details for your test configuration
Had some issues with the exit code -41 but didn't affect the testing

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
